### PR TITLE
ci: 🐎update the github action version from v2 to v3

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,7 +9,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: nrwl/nx-set-shas@v3


### PR DESCRIPTION
The ci failed because of the node version, witch is now need to be node16. The fix is already present in the v3 of the github action hook